### PR TITLE
Add task batching example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ A curated collection of Nextflow implementation patterns
 * [Optional input](docs/optional-input.adoc)
 * [Optional output](docs/optional-output.adoc)
 * [Process when empty](docs/process-when-empty.adoc)
+* [Task batching](docs/task-batching.adoc)

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -60,5 +60,6 @@ include::feedback-loop.adoc[]
 include::optional-input.adoc[]
 include::optional-output.adoc[]
 include::process-when-empty.adoc[]
+include::task-batching.adoc[]
 :leveloffset: -2
 

--- a/docs/task-batching.adoc
+++ b/docs/task-batching.adoc
@@ -1,0 +1,40 @@
+= Task Batching
+
+== Problem 
+
+You have many small tasks that you would like to process in batches to reduce job submission overhead.
+
+== Solution
+
+Use the https://www.nextflow.io/docs/latest/operator.html#buffer[buffer] operator to collect your input channel into batches, then refactor the process to accept a list of inputs instead of one input. One job will be created for each batch instead of each task.
+
+== Code 
+
+[source,nextflow,linenums,options="nowrap"]
+----
+process foo {
+    input:
+    val indices
+
+    script:
+    """
+    for INDEX in ${indices.join(' ')}; do
+        echo "Hello from task \${INDEX}!"
+    done
+    """
+}
+
+workflow {
+    Channel.of(1..1000)
+        | buffer(size: 10, remainder: true)
+        | foo
+}
+----
+
+== Run it
+
+Run the example using this command:
+
+```
+nextflow run patterns/task-batching.nf
+```

--- a/task-batching.nf
+++ b/task-batching.nf
@@ -1,0 +1,48 @@
+#!/usr/bin/env nextflow
+
+/*
+ * Copyright (c) 2022, Seqera Labs.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+ /*
+  * author Ben Sherman <bentshermann@gmail.com>
+  */
+
+params.n_tasks = 1000
+params.batch_size = 10
+
+process foo {
+    input:
+    val indices
+
+    script:
+    """
+    for INDEX in ${indices.join(' ')}; do
+        echo "Hello from task \${INDEX}!"
+    done
+    """
+}
+
+workflow {
+    Channel.of(1..params.n_tasks)
+        | buffer(size: params.batch_size, remainder: true)
+        | foo
+}


### PR DESCRIPTION
This PR adds an example for refactoring a small process to execute in batches, in order to minimize job submission overhead. It is intended to demonstrate a partial solution to task grouping until we have a better native solution.