### PR TITLE
Add nextflow.config and use full github repo path

### DIFF
--- a/docs/channel-duplication.md
+++ b/docs/channel-duplication.md
@@ -38,5 +38,5 @@ workflow {
 Use the the following command to execute the example:
 
 ```bash
-nextflow run patterns/channel-duplication.nf
+nextflow run nextflow-io/patterns/channel-duplication.nf
 ```

--- a/docs/collect-into-file.md
+++ b/docs/collect-into-file.md
@@ -34,5 +34,5 @@ workflow {
 Use the the following command to execute the example:
 
 ```bash
-nextflow run patterns/collect-into-file.nf
+nextflow run nextflow-io/patterns/collect-into-file.nf
 ```

--- a/docs/conditional-process.md
+++ b/docs/conditional-process.md
@@ -70,14 +70,14 @@ workflow {
 Use the the following command to execute the example:
 
 ```bash
-nextflow run patterns/conditional-process.nf
+nextflow run nextflow-io/patterns/conditional-process.nf
 ```
 
 The processes `foo` and `omega` are executed. Run the same command 
 with the `--flag` command line option. 
 
 ```bash
-nextflow run patterns/conditional-process.nf --flag 
+nextflow run nextflow-io/patterns/conditional-process.nf --flag 
 ```
 
 This time the processes `bar` and `omega` are executed.
@@ -149,5 +149,5 @@ workflow {
 ## Run it 
 
 ```bash
-nextflow run patterns/conditional-process2.nf
+nextflow run nextflow-io/patterns/conditional-process2.nf
 ```

--- a/docs/conditional-resources.md
+++ b/docs/conditional-resources.md
@@ -36,5 +36,5 @@ workflow {
 ## Run it 
 
 ```bash
-nextflow run patterns/conditional-resources.nf
+nextflow run nextflow-io/patterns/conditional-resources.nf
 ```

--- a/docs/feedback-loop.md
+++ b/docs/feedback-loop.md
@@ -111,8 +111,8 @@ Use the the following command to execute the example:
 
 ```
 # iterative process
-nextflow run patterns/feedback-loop-process.nf
+nextflow run nextflow-io/patterns/feedback-loop-process.nf
 
 # iterative workflow
-nextflow run patterns/feedback-loop-workflow.nf
+nextflow run nextflow-io/patterns/feedback-loop-workflow.nf
 ```

--- a/docs/ignore-failing-process.md
+++ b/docs/ignore-failing-process.md
@@ -36,5 +36,5 @@ workflow {
 Run the script with the following command: 
 
 ```bash
-nextflow run patterns/ignore-failing-process.nf 
+nextflow run nextflow-io/patterns/ignore-failing-process.nf 
 ```

--- a/docs/optional-input.md
+++ b/docs/optional-input.md
@@ -38,11 +38,11 @@ workflow {
 Run the script with the following command: 
 
 ```bash
-nextflow run patterns/optional-input.nf 
+nextflow run nextflow-io/patterns/optional-input.nf 
 ```
 
 Run the same script providing an optional file input:
 
 ```bash
-nextflow run patterns/optional-input.nf --filter foo.txt
+nextflow run nextflow-io/patterns/optional-input.nf --filter foo.txt
 ```

--- a/docs/optional-output.md
+++ b/docs/optional-output.md
@@ -29,5 +29,5 @@ workflow {
 Use the the following command to execute the example:
 
 ```bash
-nextflow run patterns/optional-output.nf
+nextflow run nextflow-io/patterns/optional-output.nf
 ```

--- a/docs/process-collect.md
+++ b/docs/process-collect.md
@@ -45,5 +45,5 @@ workflow {
 Use the the following command to execute the example:
 
 ```bash
-nextflow run patterns/process-collect.nf
+nextflow run nextflow-io/patterns/process-collect.nf
 ```

--- a/docs/process-get-workdir.md
+++ b/docs/process-get-workdir.md
@@ -39,12 +39,12 @@ workflow {
 The command run the script with an empty channel: 
 
 ```bash
-nextflow run patterns/process-get-workdir.nf
+nextflow run nextflow-io/patterns/process-get-workdir.nf
 ```
 
 Use the following command to provide the same script
 some input files, that prevents the process from being executed: 
 
 ```bash
-nextflow run patterns/process-get-workdir.nf --inputs ../data/prots/\*
+nextflow run nextflow-io/patterns/process-get-workdir.nf --inputs ../data/prots/\*
 ```

--- a/docs/process-into-groups.md
+++ b/docs/process-into-groups.md
@@ -36,5 +36,5 @@ workflow {
 ## Run it 
 
 ```bash
-nextflow run patterns/process-into-groups.nf
+nextflow run nextflow-io/patterns/process-into-groups.nf
 ```

--- a/docs/process-per-csv-record.md
+++ b/docs/process-per-csv-record.md
@@ -50,5 +50,5 @@ workflow {
 Use the the following command to execute the example:
 
 ```bash
-nextflow run patterns/process-per-csv-record.nf
+nextflow run nextflow-io/patterns/process-per-csv-record.nf
 ```

--- a/docs/process-per-file-chunk.md
+++ b/docs/process-per-file-chunk.md
@@ -40,5 +40,5 @@ workflow {
 Use the the following command to execute the example:
 
 ```bash
-nextflow run patterns/process-per-file-chunk.nf
+nextflow run nextflow-io/patterns/process-per-file-chunk.nf
 ```

--- a/docs/process-per-file-output.md
+++ b/docs/process-per-file-output.md
@@ -45,5 +45,5 @@ workflow {
 Use the the following command to execute the example:
 
 ```bash
-nextflow run patterns/process-per-file-output.nf
+nextflow run nextflow-io/patterns/process-per-file-output.nf
 ```

--- a/docs/process-per-file-pairs.md
+++ b/docs/process-per-file-pairs.md
@@ -32,7 +32,7 @@ workflow {
 ## Run it 
 
 ```bash
-nextflow run patterns/process-per-file-pairs.nf
+nextflow run nextflow-io/patterns/process-per-file-pairs.nf
 ```
 
 ## Custom grouping strategy
@@ -62,5 +62,5 @@ workflow {
 ## Run it 
 
 ```bash
-nextflow run patterns/process-per-file-pairs-custom.nf
+nextflow run nextflow-io/patterns/process-per-file-pairs-custom.nf
 ```

--- a/docs/process-per-file-path.md
+++ b/docs/process-per-file-path.md
@@ -30,5 +30,5 @@ workflow {
 Use the the following command to execute the example:
 
 ```bash
-nextflow run patterns/process-per-file-path.nf
+nextflow run nextflow-io/patterns/process-per-file-path.nf
 ```

--- a/docs/process-per-file-range.md
+++ b/docs/process-per-file-range.md
@@ -31,5 +31,5 @@ workflow {
 ## Run it 
 
 ```bash
-nextflow run patterns/process-per-file-range.nf
+nextflow run nextflow-io/patterns/process-per-file-range.nf
 ```

--- a/docs/process-when-empty.md
+++ b/docs/process-when-empty.md
@@ -40,11 +40,11 @@ workflow {
 Use the following command to run the script with an empty channel: 
 
 ```bash
-nextflow run patterns/process-when-empty.nf
+nextflow run nextflow-io/patterns/process-when-empty.nf
 ```
 
 Use the following command to provide the same script some input files, which prevents the process from being executed: 
 
 ```bash
-nextflow run patterns/process-when-empty.nf --inputs ../data/prots/\*
+nextflow run nextflow-io/patterns/process-when-empty.nf --inputs ../data/prots/\*
 ```

--- a/docs/publish-matching-glob.md
+++ b/docs/publish-matching-glob.md
@@ -45,5 +45,5 @@ workflow {
 Run the script with the following command:
 
 ```bash
-nextflow run patterns/publish-matching-glob.nf
+nextflow run nextflow-io/patterns/publish-matching-glob.nf
 ```

--- a/docs/publish-process-outputs.md
+++ b/docs/publish-process-outputs.md
@@ -37,5 +37,5 @@ workflow {
 Run the script with the following command: 
 
 ```bash
-nextflow run patterns/publish-process-outputs.nf 
+nextflow run nextflow-io/patterns/publish-process-outputs.nf 
 ```

--- a/docs/publish-rename-outputs.md
+++ b/docs/publish-rename-outputs.md
@@ -31,7 +31,7 @@ workflow {
 ## Run it 
 
 ```bash
-nextflow run patterns/publish-rename-outputs.nf
+nextflow run nextflow-io/patterns/publish-rename-outputs.nf
 ```
 
 ## Save outputs in a sub-directory
@@ -62,5 +62,5 @@ workflow {
 ## Run it 
 
 ```bash
-nextflow run patterns/publish-rename-outputs-subdirs.nf
+nextflow run nextflow-io/patterns/publish-rename-outputs-subdirs.nf
 ```

--- a/docs/skip-process-execution.md
+++ b/docs/skip-process-execution.md
@@ -53,13 +53,13 @@ workflow {
 Use the the following command to execute the example:
 
 ```bash
-nextflow run patterns/skip-process-execution.nf
+nextflow run nextflow-io/patterns/skip-process-execution.nf
 ```
 
 The processes `foo` and `bar` are executed. Run the same command with the `--skip` command line option:
 
 ```bash
-nextflow run patterns/skip-process-execution.nf --skip
+nextflow run nextflow-io/patterns/skip-process-execution.nf --skip
 ```
 
 This time only the `bar` process is executed.

--- a/docs/state-dependency.md
+++ b/docs/state-dependency.md
@@ -41,5 +41,5 @@ workflow {
 Run the example using this command:
 
 ```bash
-nextflow run patterns/state-dependency.nf
+nextflow run nextflow-io/patterns/state-dependency.nf
 ```

--- a/docs/task-batching.md
+++ b/docs/task-batching.md
@@ -33,5 +33,5 @@ workflow {
 Run the example using this command:
 
 ```bash
-nextflow run patterns/task-batching.nf
+nextflow run nextflow-io/patterns/task-batching.nf
 ```

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,0 +1,3 @@
+manifest {
+  description = 'A curated collection of Nextflow implementation patterns' 
+}


### PR DESCRIPTION
This PR address the following 

**1.** The warning which is thrown while running the examples since there is no `config` file.

```
Pulling nextflow-io/patterns ...
WARN: Cannot read project manifest -- Cause: Remote resource not found: https://api.github.com/repos/nextflow-io/patterns/contents/nextflow.config
 downloaded from https://github.com/nextflow-io/patterns.git
```

**2.** Possible confusion regarding the repo name. 

Continuing the discussion from https://github.com/nextflow-io/patterns/pull/33#issuecomment-1294946428 

> I don't follow sorry. Why are they not relevant?

@ewels, sorry it was me being tunnel-visioned at the moment and when I looked at `nextflow run pattern/file-name.nf` I thought, the users are supposed to clone the repo locally and then run it - which they don't of course and it works fine.

In this PR, I've added the full `nextflow-io` Github org name so (hopefully) others don't come across the same confusion and it'll avoid the case when people already have the same repo name already clone (via a fork) 

```
+  >_ nextflow run patterns/conditional-resources.nf
N E X T F L O W  ~  version 22.10.0
Which one do you mean?
nextflow-io/patterns
abhi18av/patterns

```