### PR TITLE
Add workflow grouping pattern

### DIFF
--- a/docs/workflow-grouping.md
+++ b/docs/workflow-grouping.md
@@ -1,4 +1,4 @@
-## Problem 
+## Problem
 
 You have a subworkflow, and you would like to limit the number of parallel subworkflow executions.
 
@@ -8,7 +8,7 @@ For a single process, you could use the [maxForks](https://nextflow.io/docs/late
 
 The following example is based on a "diamond-shaped" subworkflow, in order to show how to implement parallel steps in a Bash script. View the [complete example](https://github.com/nextflow-io/patterns/blob/master/workflow-grouping.nf) to see the original subworkflow.
 
-## Code 
+## Code
 
 ```groovy
 params.n_groups = 10
@@ -17,8 +17,11 @@ params.queue_size = 2
 process diamond_merged {
     maxForks params.queue_size
 
-    input: val(index)
-    output: tuple val(index), path('d.txt')
+    input:
+    val(index)
+
+    output:
+    tuple val(index), path('d.txt')
 
     script:
     """

--- a/docs/workflow-grouping.md
+++ b/docs/workflow-grouping.md
@@ -1,0 +1,65 @@
+## Problem 
+
+You have a subworkflow, and you would like to limit the number of parallel subworkflow executions.
+
+## Solution
+
+For a single process, you could use the [maxForks](https://nextflow.io/docs/latest/process.html#maxforks) directive to limit the number of parallel process executions. For a subworkflow, you can achieve the same effect by merging the subworkflow's processes into a single process, and then using `maxForks` or the `executor.queueSize` config option.
+
+The following example is based on a "diamond-shaped" subworkflow, in order to show how to implement parallel steps in a Bash script. View the [complete example](https://github.com/nextflow-io/patterns/blob/master/workflow-grouping.nf) to see the original subworkflow.
+
+## Code 
+
+```groovy
+params.n_groups = 10
+params.queue_size = 2
+
+process diamond_merged {
+    maxForks params.queue_size
+
+    input: val(index)
+    output: tuple val(index), path('d.txt')
+
+    script:
+    """
+    sleep 1
+
+    # process A
+    echo "subworkflow ${index}, process A was here" >> a.txt
+
+    # process B
+    process_b() {
+        cat a.txt >> b.txt
+        echo "subworkflow ${index}, process B was here" >> b.txt
+    }
+    process_b &
+
+    # process C
+    process_c() {
+        cat a.txt >> c.txt
+        echo "subworkflow ${index}, process C was here" >> c.txt
+    }
+    process_c &
+
+    wait
+
+    # process D
+    cat b.txt >> d.txt
+    cat c.txt >> d.txt
+    echo "subworkflow ${index}, process D was here" >> d.txt
+    """
+}
+
+workflow {
+    Channel.of(1..params.n_groups)
+      | diamond_merged
+}
+```
+
+## Run it
+
+Run the example using this command:
+
+```bash
+nextflow run nextflow-io/patterns/workflow-grouping.nf
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
     - 'Optional output': 'optional-output.md'
     - 'Process when empty': 'process-when-empty.md'
     - 'Task batching': 'task-batching.md'
+    - 'Workflow grouping': 'workflow-grouping.md'
 
 extra:
   analytics:

--- a/workflow-grouping.nf
+++ b/workflow-grouping.nf
@@ -1,0 +1,131 @@
+#!/usr/bin/env nextflow
+
+/*
+ * Copyright (c) 2023, Seqera Labs.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+ /*
+  * author Ben Sherman <bentshermann@gmail.com>
+  */
+
+params.n_groups = 10
+params.queue_size = 2
+
+process A {
+    input: val(index)
+    output: tuple val(index), path('output.txt')
+
+    script:
+    """
+    sleep 1
+
+    echo "subworkflow ${index}, process A was here" >> output.txt
+    """
+}
+
+process B {
+    input: tuple val(index), path('input.txt')
+    output: tuple val(index), path('output.txt')
+
+    script:
+    """
+    sleep 1
+
+    cat input.txt >> output.txt
+    echo "subworkflow ${index}, process B was here" >> output.txt
+    """
+}
+
+process C {
+    input: tuple val(index), path('input.txt')
+    output: tuple val(index), path('output.txt')
+
+    script:
+    """
+    sleep 1
+
+    cat input.txt >> output.txt
+    echo "subworkflow ${index}, process C was here" >> output.txt
+    """
+}
+
+process D {
+    input: tuple val(index), path('input_b.txt'), path('input_c.txt')
+    output: tuple val(index), path('output.txt')
+
+    script:
+    """
+    sleep 1
+
+    cat input_b.txt >> output.txt
+    cat input_c.txt >> output.txt
+    echo "subworkflow ${index}, process D was here" >> output.txt
+    """
+}
+
+workflow diamond {
+    Channel.of(1..params.n_groups)
+      | A
+      | (B & C)
+      | join
+      | D
+}
+
+process diamond_merged {
+    maxForks params.queue_size
+
+    input: val(index)
+    output: tuple val(index), path('d.txt')
+
+    script:
+    """
+    sleep 1
+
+    # process A
+    echo "subworkflow ${index}, process A was here" >> a.txt
+
+    # process B
+    process_b() {
+        cat a.txt >> b.txt
+        echo "subworkflow ${index}, process B was here" >> b.txt
+    }
+    process_b &
+
+    # process C
+    process_c() {
+        cat a.txt >> c.txt
+        echo "subworkflow ${index}, process C was here" >> c.txt
+    }
+    process_c &
+
+    wait
+
+    # process D
+    cat b.txt >> d.txt
+    cat c.txt >> d.txt
+    echo "subworkflow ${index}, process D was here" >> d.txt
+    """
+}
+
+workflow {
+    Channel.of(1..params.n_groups)
+      | diamond_merged
+}

--- a/workflow-grouping.nf
+++ b/workflow-grouping.nf
@@ -9,10 +9,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -30,8 +30,11 @@ params.n_groups = 10
 params.queue_size = 2
 
 process A {
-    input: val(index)
-    output: tuple val(index), path('output.txt')
+    input:
+    val(index)
+
+    output:
+    tuple val(index), path('output.txt')
 
     script:
     """
@@ -42,8 +45,11 @@ process A {
 }
 
 process B {
-    input: tuple val(index), path('input.txt')
-    output: tuple val(index), path('output.txt')
+    input:
+    tuple val(index), path('input.txt')
+
+    output:
+    tuple val(index), path('output.txt')
 
     script:
     """
@@ -55,8 +61,11 @@ process B {
 }
 
 process C {
-    input: tuple val(index), path('input.txt')
-    output: tuple val(index), path('output.txt')
+    input:
+    tuple val(index), path('input.txt')
+
+    output:
+    tuple val(index), path('output.txt')
 
     script:
     """
@@ -68,8 +77,11 @@ process C {
 }
 
 process D {
-    input: tuple val(index), path('input_b.txt'), path('input_c.txt')
-    output: tuple val(index), path('output.txt')
+    input:
+    tuple val(index), path('input_b.txt'), path('input_c.txt')
+
+    output:
+    tuple val(index), path('output.txt')
 
     script:
     """
@@ -92,8 +104,11 @@ workflow diamond {
 process diamond_merged {
     maxForks params.queue_size
 
-    input: val(index)
-    output: tuple val(index), path('d.txt')
+    input:
+    val(index)
+
+    output:
+    tuple val(index), path('d.txt')
 
     script:
     """


### PR DESCRIPTION
This PR adds a pattern that demonstrates how to control the parallelism of a subworkflow. It is a workaround until https://github.com/nextflow-io/nextflow/issues/2527 is implemented.

See also this Slack discussion: https://nextflow.slack.com/archives/C02T98A23U7/p1674653918115269